### PR TITLE
feat(inventory): add unit ticket print functionality

### DIFF
--- a/api/auth/user/user.model.js
+++ b/api/auth/user/user.model.js
@@ -26,6 +26,9 @@ module.exports = (sequelize, DataTypes) => {
     static associate(models) {
       // define association here
       User.hasMany(models.ProductBoxLog);
+      User.hasMany(models.ProductBarcode, { foreignKey: 'createdBy' });
+      User.hasMany(models.InventoryMovement);
+      User.hasMany(models.UnitTicketPrint);
       User.hasMany(models.Proforma);
 
       User.hasMany(models.Sale, { foreignKey: 'cashierId' });

--- a/api/inventory/inventory.router.js
+++ b/api/inventory/inventory.router.js
@@ -46,6 +46,26 @@ router.use(
   require('./product/product.router'),
 );
 router.use(
+  '/product-barcodes',
+  authenticateMiddleware('jwt'),
+  require('./productBarcode/productBarcode.router'),
+);
+router.use(
+  '/inventory-codes',
+  authenticateMiddleware('jwt'),
+  require('./inventoryCode/inventoryCode.router'),
+);
+router.use(
+  '/unit-ticket-prints',
+  authenticateMiddleware('jwt'),
+  require('./unitTicketPrint/unitTicketPrint.router'),
+);
+router.use(
+  '/reconciliations',
+  authenticateMiddleware('jwt'),
+  require('./reconciliation/reconciliation.router'),
+);
+router.use(
   '/productboxes',
   authenticateMiddleware('jwt'),
   require('./productbox/productbox.router'),

--- a/api/inventory/inventoryCode/inventoryCode.controller.js
+++ b/api/inventory/inventoryCode/inventoryCode.controller.js
@@ -1,0 +1,6 @@
+const Service = require('./inventoryCode.service');
+const resolve = async (req, res) => {
+  const response = await Service.resolve(req.params);
+  return res.status(response.status).send(response);
+};
+module.exports = { resolve };

--- a/api/inventory/inventoryCode/inventoryCode.router.js
+++ b/api/inventory/inventoryCode/inventoryCode.router.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { celebrate, Joi } = require('celebrate');
+const { isAble } = require('@/middleware/authorization');
+const Controller = require('./inventoryCode.controller');
+
+const router = express.Router();
+router.get('/:code', isAble('read', 'inventory'), celebrate({ params: { code: Joi.string().pattern(/^\d+$/).required() } }), Controller.resolve);
+module.exports = router;

--- a/api/inventory/inventoryCode/inventoryCode.service.js
+++ b/api/inventory/inventoryCode/inventoryCode.service.js
@@ -1,0 +1,112 @@
+const { Op } = require('sequelize');
+const {
+  InventoryMovement,
+  Product,
+  ProductBarcode,
+  ProductBox,
+  ProductBoxLog,
+  Provider,
+  UnitTicketPrint,
+  User,
+  Warehouse,
+} = require('@dbModels');
+const { setResponse, warehouseTypes } = require('@/utils');
+const { ensureProductBarcode } = require('../productBarcode/productBarcode.service');
+
+const resolveBox = async code => {
+  const productBox = await ProductBox.findOne({
+    where: { trackingCode: code },
+    include: [
+      { model: Product, include: [Provider] },
+      Warehouse,
+      { model: User, as: 'explodedByUser', attributes: ['id', 'name', 'lastname'] },
+      {
+        model: ProductBox,
+        as: 'explodedLots',
+        include: [
+          Warehouse,
+          { model: User, as: 'explodedByUser', attributes: ['id', 'name', 'lastname'] },
+        ],
+      },
+      { model: ProductBox, as: 'originProductBox' },
+      {
+        model: ProductBoxLog,
+        include: [
+          { model: Warehouse, attributes: ['id', 'name', 'type'] },
+          { model: User, attributes: ['id', 'name', 'lastname'] },
+        ],
+      },
+    ],
+    order: [[{ model: ProductBoxLog }, 'createdAt', 'DESC']],
+  });
+  if (!productBox)
+    return setResponse(404, 'Inventory code not found.', null, 'Código de inventario no encontrado.');
+  const barcode = await ensureProductBarcode(productBox.product);
+  const movements = await InventoryMovement.findAll({
+    where: {
+      [Op.or]: [
+        { sourceProductBoxId: productBox.id },
+        { targetProductBoxId: productBox.id },
+      ],
+    },
+    order: [['createdAt', 'DESC']],
+  });
+  return setResponse(200, 'Inventory code found.', {
+    type: 'BOX',
+    code,
+    productBox,
+    product: productBox.product,
+    productBarcode: barcode,
+    inventoryMovements: movements,
+  });
+};
+
+const resolveProduct = async code => {
+  const barcode = await ProductBarcode.findOne({
+    where: { barcode: code, type: 'UNIT_PRODUCT', isActive: true },
+    include: [{ model: Product, include: [Provider] }],
+  });
+  if (!barcode)
+    return setResponse(404, 'Inventory code not found.', null, 'Código de inventario no encontrado.');
+  const lots = await ProductBox.findAll({
+    where: { productId: barcode.productId, inventoryKind: 'EXPLODED', stock: { [Op.gt]: 0 } },
+    include: [
+      { model: Warehouse, where: { type: warehouseTypes.STORE } },
+      { model: ProductBox, as: 'originProductBox' },
+    ],
+    order: [['createdAt', 'ASC'], ['id', 'ASC']],
+  });
+  const stockByStore = Object.values(lots.reduce((acc, lot) => {
+    if (!acc[lot.warehouseId])
+      acc[lot.warehouseId] = {
+        warehouseId: lot.warehouseId,
+        warehouseName: lot.warehouse.name,
+        stock: 0,
+      };
+    acc[lot.warehouseId].stock += lot.stock;
+    return acc;
+  }, {}));
+  const [movements, prints] = await Promise.all([
+    InventoryMovement.findAll({ where: { productId: barcode.productId }, order: [['createdAt', 'DESC']], limit: 200 }),
+    UnitTicketPrint.findAll({ where: { productId: barcode.productId }, order: [['createdAt', 'DESC']], limit: 100 }),
+  ]);
+  return setResponse(200, 'Inventory code found.', {
+    type: 'PRODUCT',
+    code,
+    productBarcode: barcode,
+    product: barcode.product,
+    unitLots: lots,
+    stockByStore,
+    inventoryMovements: movements,
+    ticketPrints: prints,
+  });
+};
+
+const resolve = async reqParams => {
+  const code = String(reqParams.code || '').trim();
+  if (code.startsWith('1')) return resolveBox(code);
+  if (code.startsWith('2')) return resolveProduct(code);
+  return setResponse(400, 'Invalid inventory code.', null, 'El código debe iniciar con 1 o 2.');
+};
+
+module.exports = { resolve };

--- a/api/inventory/inventoryMovement/inventoryMovement.model.js
+++ b/api/inventory/inventoryMovement/inventoryMovement.model.js
@@ -1,0 +1,56 @@
+const { Model } = require('sequelize');
+
+module.exports = (sequelize, DataTypes) => {
+  class InventoryMovement extends Model {
+    static associate(models) {
+      InventoryMovement.belongsTo(models.Product);
+      InventoryMovement.belongsTo(models.ProductBox, {
+        as: 'sourceProductBox',
+        foreignKey: 'sourceProductBoxId',
+      });
+      InventoryMovement.belongsTo(models.ProductBox, {
+        as: 'targetProductBox',
+        foreignKey: 'targetProductBoxId',
+      });
+      InventoryMovement.belongsTo(models.Warehouse, {
+        as: 'fromWarehouse',
+        foreignKey: 'fromWarehouseId',
+      });
+      InventoryMovement.belongsTo(models.Warehouse, {
+        as: 'toWarehouse',
+        foreignKey: 'toWarehouseId',
+      });
+      InventoryMovement.belongsTo(models.User);
+      InventoryMovement.belongsTo(models.Supply);
+      InventoryMovement.belongsTo(models.Dispatch);
+      InventoryMovement.belongsTo(models.InventoryReconciliation, {
+        foreignKey: 'reconciliationId',
+      });
+    }
+  }
+
+  InventoryMovement.init(
+    {
+      type: { type: DataTypes.STRING, allowNull: false },
+      quantity: { type: DataTypes.INTEGER, allowNull: false },
+      productId: { type: DataTypes.INTEGER, allowNull: false },
+      sourceProductBoxId: DataTypes.INTEGER,
+      targetProductBoxId: DataTypes.INTEGER,
+      fromWarehouseId: DataTypes.INTEGER,
+      toWarehouseId: DataTypes.INTEGER,
+      sourceStockBefore: DataTypes.INTEGER,
+      sourceStockAfter: DataTypes.INTEGER,
+      targetStockBefore: DataTypes.INTEGER,
+      targetStockAfter: DataTypes.INTEGER,
+      userId: DataTypes.INTEGER,
+      supplyId: DataTypes.INTEGER,
+      dispatchId: DataTypes.INTEGER,
+      reconciliationId: DataTypes.INTEGER,
+      description: DataTypes.TEXT,
+      metadata: DataTypes.JSONB,
+    },
+    { sequelize, modelName: 'inventoryMovement' },
+  );
+
+  return InventoryMovement;
+};

--- a/api/inventory/inventoryTransaction.service.js
+++ b/api/inventory/inventoryTransaction.service.js
@@ -1,0 +1,159 @@
+const {
+  InventoryMovement,
+  Product,
+  ProductBox,
+  Warehouse,
+} = require('@dbModels');
+const { sequelize } = require('@root/startup/db');
+const {
+  PRODUCTBOX_UPDATES,
+  warehouseTypes,
+} = require('@/utils/constants');
+
+class InventoryOperationError extends Error {
+  constructor(userMessage, status = 400) {
+    super(userMessage);
+    this.userMessage = userMessage;
+    this.status = status;
+  }
+}
+
+const registerMovement = (values, transaction) =>
+  InventoryMovement.create(values, { transaction });
+
+const moveLockedProductBox = async ({ productBoxId, warehouseId }, user, transaction) => {
+  const productBox = await ProductBox.findByPk(productBoxId, {
+    transaction,
+    lock: transaction.LOCK.UPDATE,
+  });
+  if (!productBox) throw new InventoryOperationError('Caja no encontrada.', 404);
+  if (productBox.inventoryKind !== 'PHYSICAL' || productBox.lifecycleStatus !== 'ACTIVE')
+    throw new InventoryOperationError('La caja ya fue explotada y no puede volver a moverse.');
+
+  const destination = await Warehouse.findByPk(warehouseId, {
+    transaction,
+    lock: transaction.LOCK.SHARE,
+  });
+  if (!destination) throw new InventoryOperationError('Ubicación destino no encontrada.', 404);
+  if (destination.type === warehouseTypes.ADJUSTMENT)
+    throw new InventoryOperationError('AjusteInventario solo puede recibir unidades mediante reconciliación.');
+  if (
+    productBox.warehouseId === warehouseId &&
+    destination.type !== warehouseTypes.STORE
+  )
+    throw new InventoryOperationError('Debe seleccionar una ubicación distinta.');
+
+  const previousWarehouseId = productBox.warehouseId;
+  const quantity = productBox.stock;
+
+  if (destination.type !== warehouseTypes.STORE) {
+    await productBox.update(
+      { warehouseId, previousWarehouseId },
+      { transaction },
+    );
+    await productBox.registerLog(PRODUCTBOX_UPDATES.MOVEMENT.value, user, { transaction });
+    await registerMovement(
+      {
+        type: 'BOX_MOVE',
+        quantity,
+        productId: productBox.productId,
+        sourceProductBoxId: productBox.id,
+        fromWarehouseId: previousWarehouseId,
+        toWarehouseId: warehouseId,
+        sourceStockBefore: quantity,
+        sourceStockAfter: quantity,
+        userId: user.id,
+        description: 'Movimiento de caja física',
+      },
+      transaction,
+    );
+    return { productBox, explodedLot: null, wasExploded: false };
+  }
+
+  if (quantity <= 0)
+    throw new InventoryOperationError('La caja no tiene unidades disponibles para explotar.');
+
+  const explodedLot = await ProductBox.create(
+    {
+      trackingCode: null,
+      boxSize: quantity,
+      stock: quantity,
+      isAvailable: true,
+      inventoryKind: 'EXPLODED',
+      lifecycleStatus: 'ACTIVE',
+      originProductBoxId: productBox.id,
+      explodedAt: new Date(),
+      explodedBy: user.id,
+      sourceType: 'BOX_EXPLOSION',
+      productId: productBox.productId,
+      warehouseId,
+      supplyId: productBox.supplyId,
+    },
+    { transaction },
+  );
+
+  await productBox.update(
+    {
+      warehouseId,
+      previousWarehouseId,
+      stock: 0,
+      isAvailable: false,
+      lifecycleStatus: 'DISCARDED',
+      explodedAt: new Date(),
+      explodedBy: user.id,
+    },
+    { transaction },
+  );
+  await productBox.registerLog(`Caja explotada (${quantity} unidades)`, user, { transaction });
+  await registerMovement(
+    {
+      type: 'BOX_EXPLOSION',
+      quantity,
+      productId: productBox.productId,
+      sourceProductBoxId: productBox.id,
+      targetProductBoxId: explodedLot.id,
+      fromWarehouseId: previousWarehouseId,
+      toWarehouseId: warehouseId,
+      sourceStockBefore: quantity,
+      sourceStockAfter: 0,
+      targetStockBefore: 0,
+      targetStockAfter: quantity,
+      userId: user.id,
+      supplyId: productBox.supplyId,
+      description: 'Caja recibida en tienda y convertida a unidades',
+    },
+    transaction,
+  );
+  return { productBox, explodedLot, wasExploded: true };
+};
+
+const moveProductBoxes = async (boxes, user) => {
+  const transaction = await sequelize.transaction();
+  try {
+    const results = [];
+    for (const box of boxes) {
+      results.push(
+        await moveLockedProductBox(
+          { productBoxId: box.id, warehouseId: box.warehouseId },
+          user,
+          transaction,
+        ),
+      );
+    }
+    const productIds = [...new Set(results.map(result => result.productBox.productId))];
+    for (const productId of productIds)
+      await Product.updateStock(productId, { transaction });
+    await transaction.commit();
+    return results;
+  } catch (error) {
+    await transaction.rollback();
+    throw error;
+  }
+};
+
+module.exports = {
+  InventoryOperationError,
+  moveLockedProductBox,
+  moveProductBoxes,
+  registerMovement,
+};

--- a/api/inventory/product/product.model.js
+++ b/api/inventory/product/product.model.js
@@ -16,6 +16,10 @@ module.exports = (sequelize, DataTypes) => {
       Product.belongsTo(models.Model, { foreignKey: 'id' });
 
       Product.hasMany(models.ProductBox);
+      Product.hasMany(models.ProductBarcode);
+      Product.hasMany(models.InventoryMovement);
+      Product.hasMany(models.UnitTicketPrint);
+      Product.hasMany(models.InventoryReconciliation);
 
       Product.hasMany(models.SuppliedProduct);
       Product.hasMany(models.ProformaProduct);
@@ -58,6 +62,7 @@ module.exports = (sequelize, DataTypes) => {
       if (includeBoxSizeDetail)
         product.stockByWarehouseAndBoxSize = Object.values(
           product.productBoxes.reduce((accumulator, currentValue) => {
+            if (currentValue.inventoryKind === 'EXPLODED') return accumulator;
             const key = `${currentValue.warehouse.id}-${currentValue.boxSize}`;
             if (!_.get(accumulator, [key]))
               accumulator[key] = {
@@ -117,6 +122,13 @@ module.exports = (sequelize, DataTypes) => {
         'stock',
         0,
       );
+      const adjustmentStock = _.get(
+        summary.stockByWarehouseType.find(
+          obj => obj.warehouseType === warehouseTypes.ADJUSTMENT,
+        ),
+        'stock',
+        0,
+      );
       // ? Unidades vendidas
       const soldStock =
         (await SoldProduct.sum('quantity', {
@@ -133,9 +145,14 @@ module.exports = (sequelize, DataTypes) => {
       await product.update(
         {
           damagedStock,
+          adjustmentStock,
           availableStock:
-            summary.totalStock - damagedStock - (soldStock - dispatchedStock),
-          dispatchStock: summary.totalStock - damagedStock,
+            summary.totalStock -
+            damagedStock -
+            adjustmentStock -
+            (soldStock - dispatchedStock),
+          dispatchStock:
+            summary.totalStock - damagedStock - adjustmentStock,
         },
         { transaction: _.get(options, 'transaction') },
       );
@@ -205,6 +222,10 @@ module.exports = (sequelize, DataTypes) => {
         defaultValue: 0,
       },
       damagedStock: {
+        type: DataTypes.INTEGER,
+        defaultValue: 0,
+      },
+      adjustmentStock: {
         type: DataTypes.INTEGER,
         defaultValue: 0,
       },
@@ -282,6 +303,25 @@ module.exports = (sequelize, DataTypes) => {
           product.familyName = categories.element.subfamily.family.name;
 
           product.code = `${categories.element.subfamily.family.code}-${categories.element.subfamily.code}-${categories.element.code}-${provider.code}-${categories.code}`;
+        },
+        afterCreate: async (product, options) => {
+          const { productBarcode: ProductBarcode } = product.sequelize.models;
+          if (!ProductBarcode) return;
+          await ProductBarcode.findOrCreate({
+            where: {
+              productId: product.id,
+              type: 'UNIT_PRODUCT',
+              isActive: true,
+            },
+            defaults: {
+              barcode: ProductBarcode.buildUnitBarcode(product.id),
+              productCodeSnapshot: product.code,
+              productId: product.id,
+              type: 'UNIT_PRODUCT',
+              isActive: true,
+            },
+            transaction: options.transaction,
+          });
         },
       },
     },

--- a/api/inventory/product/product.service/getInventoryReport.js
+++ b/api/inventory/product/product.service/getInventoryReport.js
@@ -13,7 +13,7 @@ const productFields = [
   'groupId',
   'tradename',
 ];
-const { warehouseTypes } = require('../../../utils/constants');
+const { warehouseTypes, productBoxKinds } = require('../../../utils/constants');
 
 const getInventoryReport = async reqQuery => {
   const productBoxes = await ProductBox.findAll({
@@ -48,12 +48,25 @@ const getInventoryReport = async reqQuery => {
     raw: true,
   });
 
+  const physicalBoxCounts = await ProductBox.count({
+    attributes: ['productId'],
+    where: {
+      inventoryKind: productBoxKinds.PHYSICAL,
+      stock: { [sequelize.Op.gt]: 0 },
+    },
+    group: ['productId'],
+  });
+  const physicalBoxCountByProduct = new Map(
+    physicalBoxCounts.map(item => [Number(item.productId), Number(item.count)]),
+  );
+
   let j = 0;
   products = products.map(product => {
     product.productBoxes = [];
     product.totalStock = 0;
     product.activeStock = 0;
     product.damagedStock = 0;
+    product.adjustmentStock = 0;
     product.storeStock = 0;
     product.warehouseStock = 0;
     while (j < productBoxes.length) {
@@ -63,6 +76,8 @@ const getInventoryReport = async reqQuery => {
         product[
           productBoxes[j].warehouse.type === warehouseTypes.DAMAGED
             ? 'damagedStock'
+            : productBoxes[j].warehouse.type === warehouseTypes.ADJUSTMENT
+            ? 'adjustmentStock'
             : 'activeStock'
         ] += productBoxes[j].get('stock');
 
@@ -89,7 +104,8 @@ const getInventoryReport = async reqQuery => {
         name: product.tradename,
         stockStore: product.storeStock,
         stockWarehouse: product.warehouseStock,
-        boxes: product.productBoxes.length,
+        stockAdjustment: product.adjustmentStock,
+        boxes: physicalBoxCountByProduct.get(product.id) || 0,
       };
     }),
   );

--- a/api/inventory/product/product.service/listProducts.js
+++ b/api/inventory/product/product.service/listProducts.js
@@ -76,14 +76,17 @@ const listProducts = async reqQuery => {
       product.totalStock = 0;
       product.activeStock = 0;
       product.damagedStock = 0;
+      product.adjustmentStock = 0;
       while (j < productBoxes.length) {
         if (productBoxes[j].productId === product.id) {
           product.productBoxes.push(productBoxes[j]);
           product.totalStock += productBoxes[j].get('stock');
           product[
-            productBoxes[j].warehouse.type === warehouseTypes.DAMAGED
-              ? 'damagedStock'
-              : 'activeStock'
+          productBoxes[j].warehouse.type === warehouseTypes.DAMAGED
+            ? 'damagedStock'
+            : productBoxes[j].warehouse.type === warehouseTypes.ADJUSTMENT
+            ? 'adjustmentStock'
+            : 'activeStock'
           ] += productBoxes[j].get('stock');
         } else break;
         j += 1;

--- a/api/inventory/product/product.service/readProduct.js
+++ b/api/inventory/product/product.service/readProduct.js
@@ -15,7 +15,13 @@ const readProduct = async reqParams => {
       {
         model: ProductBox,
         where: { stock: { [Op.gt]: 0 } },
-        attributes: ['id', 'stock', 'boxSize'],
+        attributes: [
+          'id',
+          'stock',
+          'boxSize',
+          'inventoryKind',
+          'originProductBoxId',
+        ],
         include: [
           {
             model: Warehouse,

--- a/api/inventory/productBarcode/productBarcode.controller.js
+++ b/api/inventory/productBarcode/productBarcode.controller.js
@@ -1,0 +1,12 @@
+const Service = require('./productBarcode.service');
+
+const getByProductId = async (req, res) => {
+  const response = await Service.getByProductId(req.params, req.user);
+  return res.status(response.status).send(response);
+};
+const getByCode = async (req, res) => {
+  const response = await Service.getByCode(req.params);
+  return res.status(response.status).send(response);
+};
+
+module.exports = { getByProductId, getByCode };

--- a/api/inventory/productBarcode/productBarcode.model.js
+++ b/api/inventory/productBarcode/productBarcode.model.js
@@ -1,0 +1,39 @@
+const { Model } = require('sequelize');
+const { buildUnitBarcode } = require('../unitInventory.utils');
+
+module.exports = (sequelize, DataTypes) => {
+  class ProductBarcode extends Model {
+    static associate(models) {
+      ProductBarcode.belongsTo(models.Product);
+      ProductBarcode.belongsTo(models.User, {
+        as: 'creator',
+        foreignKey: 'createdBy',
+      });
+    }
+
+    static buildUnitBarcode(productId) {
+      return buildUnitBarcode(productId);
+    }
+  }
+
+  ProductBarcode.init(
+    {
+      barcode: { type: DataTypes.STRING, allowNull: false, unique: true },
+      productId: { type: DataTypes.INTEGER, allowNull: false },
+      productCodeSnapshot: DataTypes.STRING,
+      type: { type: DataTypes.STRING, allowNull: false, defaultValue: 'UNIT_PRODUCT' },
+      isActive: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+      createdBy: DataTypes.INTEGER,
+    },
+    {
+      sequelize,
+      modelName: 'productBarcode',
+      indexes: [
+        { unique: true, fields: ['barcode'] },
+        { fields: ['productId', 'type', 'isActive'] },
+      ],
+    },
+  );
+
+  return ProductBarcode;
+};

--- a/api/inventory/productBarcode/productBarcode.router.js
+++ b/api/inventory/productBarcode/productBarcode.router.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const { celebrate } = require('celebrate');
+const Controller = require('./productBarcode.controller');
+const Validator = require('./productBarcode.validator');
+const { isAble } = require('@/middleware/authorization');
+
+const router = express.Router();
+router.get('/product/:productId', isAble('read', 'inventory'), celebrate(Validator.GetByProductId), Controller.getByProductId);
+router.get('/:barcode', isAble('read', 'inventory'), celebrate(Validator.GetByCode), Controller.getByCode);
+module.exports = router;

--- a/api/inventory/productBarcode/productBarcode.service.js
+++ b/api/inventory/productBarcode/productBarcode.service.js
@@ -1,0 +1,45 @@
+const { Product, ProductBarcode, Provider } = require('@dbModels');
+const { setResponse } = require('@/utils');
+
+const productAttributes = {
+  exclude: ['imageBase64', 'secondImageBase64', 'thirdImageBase64'],
+};
+
+const ensureProductBarcode = async (product, options = {}) => {
+  if (!product) return null;
+  const [barcode] = await ProductBarcode.findOrCreate({
+    where: { productId: product.id, type: 'UNIT_PRODUCT', isActive: true },
+    defaults: {
+      barcode: ProductBarcode.buildUnitBarcode(product.id),
+      productCodeSnapshot: product.code,
+      productId: product.id,
+      type: 'UNIT_PRODUCT',
+      isActive: true,
+      createdBy: options.userId,
+    },
+    transaction: options.transaction,
+  });
+  return barcode;
+};
+
+const getByProductId = async (reqParams, reqUser) => {
+  const product = await Product.findByPk(reqParams.productId, {
+    attributes: productAttributes,
+    include: [Provider],
+  });
+  if (!product) return setResponse(404, 'Product not found.', null, 'Producto no encontrado.');
+  const barcode = await ensureProductBarcode(product, { userId: reqUser.id });
+  return setResponse(200, 'Product barcode found.', { ...barcode.get(), product });
+};
+
+const getByCode = async reqParams => {
+  const barcode = await ProductBarcode.findOne({
+    where: { barcode: reqParams.barcode, type: 'UNIT_PRODUCT', isActive: true },
+    include: [{ model: Product, attributes: productAttributes, include: [Provider] }],
+  });
+  if (!barcode)
+    return setResponse(404, 'Product barcode not found.', null, 'Código de producto no encontrado.');
+  return setResponse(200, 'Product barcode found.', barcode);
+};
+
+module.exports = { ensureProductBarcode, getByProductId, getByCode };

--- a/api/inventory/productBarcode/productBarcode.validator.js
+++ b/api/inventory/productBarcode/productBarcode.validator.js
@@ -1,0 +1,6 @@
+const { Joi } = require('celebrate');
+
+module.exports = {
+  GetByProductId: { params: { productId: Joi.number().integer().min(1).required() } },
+  GetByCode: { params: { barcode: Joi.string().pattern(/^2\d{15}$/).required() } },
+};

--- a/api/inventory/productbox/productbox.model.js
+++ b/api/inventory/productbox/productbox.model.js
@@ -24,19 +24,33 @@ module.exports = (sequelize, DataTypes) => {
       });
       ProductBox.belongsTo(models.Supply);
       ProductBox.belongsTo(models.SuppliedProduct);
+      ProductBox.belongsTo(models.ProductBox, {
+        as: 'originProductBox',
+        foreignKey: 'originProductBoxId',
+      });
+      ProductBox.hasMany(models.ProductBox, {
+        as: 'explodedLots',
+        foreignKey: 'originProductBoxId',
+      });
+      ProductBox.belongsTo(models.User, {
+        as: 'explodedByUser',
+        foreignKey: 'explodedBy',
+      });
 
       ProductBox.hasMany(models.DispatchedProductBox);
+      ProductBox.hasMany(models.UnitTicketPrint);
     }
 
-    static bulkRegisterLog(message, user, data) {
+    static bulkRegisterLog(message, user, data, options) {
       const { productBoxLog: ProductBoxLog } = this.sequelize.models;
-      ProductBoxLog.bulkCreate(
+      return ProductBoxLog.bulkCreate(
         data.map(productBox => ({
           productBoxId: productBox.id,
           log: _.get(PRODUCTBOX_UPDATES, `${message}.name`, message),
           userId: _.get(user, 'id', user),
           warehouseId: productBox.warehouseId,
         })),
+        { transaction: _.get(options, 'transaction') },
       );
     }
 
@@ -84,6 +98,21 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.BOOLEAN,
         defaultValue: true,
       },
+      inventoryKind: {
+        type: DataTypes.STRING,
+        defaultValue: 'PHYSICAL',
+      },
+      lifecycleStatus: {
+        type: DataTypes.STRING,
+        defaultValue: 'ACTIVE',
+      },
+      originProductBoxId: DataTypes.INTEGER,
+      explodedAt: DataTypes.DATE,
+      explodedBy: DataTypes.INTEGER,
+      sourceType: {
+        type: DataTypes.STRING,
+        defaultValue: 'SUPPLY',
+      },
     },
     {
       sequelize,
@@ -102,11 +131,13 @@ module.exports = (sequelize, DataTypes) => {
       hooks: {
         // ? Generar codigo de identificacion de la caja
         beforeCreate: async productBox => {
-          productBox.trackingCode = productBox.getTrackingCode();
+          if (productBox.inventoryKind !== 'EXPLODED' && !productBox.trackingCode)
+            productBox.trackingCode = productBox.getTrackingCode();
         },
         beforeBulkCreate: async productBoxes => {
           productBoxes.forEach((obj, index, array) => {
-            array[index].trackingCode = array[index].getTrackingCode();
+            if (obj.inventoryKind !== 'EXPLODED' && !obj.trackingCode)
+              array[index].trackingCode = array[index].getTrackingCode();
           });
         },
       },

--- a/api/inventory/productbox/productbox.router.js
+++ b/api/inventory/productbox/productbox.router.js
@@ -35,14 +35,14 @@ router.get(
 
 router.put(
   '/move',
-  isAble('read', 'productBox'),
+  isAble('move', 'inventory'),
   celebrate(Validator.PutMove),
   Controller.putMoveProductBox,
 );
 
 router.put(
   '/:id',
-  isAble('read', 'productBox'),
+  isAble('move', 'inventory'),
   celebrate(Validator.Put),
   Controller.putProductBox,
 );

--- a/api/inventory/productbox/productbox.service.js
+++ b/api/inventory/productbox/productbox.service.js
@@ -10,6 +10,10 @@ const {
 const moment = require('moment-timezone');
 const { Op } = require('sequelize');
 const { setResponse } = require('../../utils');
+const {
+  InventoryOperationError,
+  moveProductBoxes,
+} = require('../inventoryTransaction.service');
 
 const getProductBox = async reqParams => {
   const productBox = await ProductBox.findOne({
@@ -23,6 +27,16 @@ const getProductBox = async reqParams => {
         },
       },
       Warehouse,
+      { model: ProductBox, as: 'originProductBox' },
+      { model: User, as: 'explodedByUser', attributes: ['id', 'name', 'lastname'] },
+      {
+        model: ProductBox,
+        as: 'explodedLots',
+        include: [
+          Warehouse,
+          { model: User, as: 'explodedByUser', attributes: ['id', 'name', 'lastname'] },
+        ],
+      },
       {
         model: ProductBoxLog,
         include: [
@@ -39,9 +53,15 @@ const getProductBox = async reqParams => {
 };
 
 const listProductBoxes = async reqQuery => {
+  const where = { ...reqQuery, inventoryKind: 'PHYSICAL' };
   const productBoxes = await ProductBox.findAll({
-    where: reqQuery,
-    include: [Warehouse, Supply, { model: Warehouse, as: 'previousWarehouse' }],
+    where,
+    include: [
+      Warehouse,
+      Supply,
+      { model: Warehouse, as: 'previousWarehouse' },
+      { model: ProductBox, as: 'explodedLots', include: [Warehouse] },
+    ],
   });
 
   return setResponse(200, 'ProductBoxs found.', productBoxes);
@@ -54,35 +74,28 @@ const createProductBox = async reqBody => {
 };
 
 const putProductBox = async (reqBody, reqParams, reqUser) => {
-  const productBox = await ProductBox.findByPk(reqParams.id);
-  if (!productBox) return setResponse(404, 'ProductBox not found.');
-  if (reqBody.warehouseId) {
-    reqBody.previousWarehouseId = productBox.dataValues.warehouseId;
-    const warehouse = await Warehouse.findByPk(reqBody.warehouseId);
-    if (!warehouse) return setResponse(404, 'Warehouse not found.');
+  try {
+    const [result] = await moveProductBoxes(
+      [{ id: Number(reqParams.id), warehouseId: reqBody.warehouseId }],
+      reqUser,
+    );
+    return setResponse(200, 'ProductBox updated.', result);
+  } catch (error) {
+    if (error instanceof InventoryOperationError)
+      return setResponse(error.status, 'ProductBox movement failed.', null, error.userMessage);
+    throw error;
   }
-  await productBox.update(reqBody);
-  productBox.registerLog(reqBody.message, reqUser);
-  return setResponse(200, 'ProductBox updated.', productBox);
 };
 
 const putMoveProductBoxes = async (reqBody, reqUser) => {
-  const { boxes } = reqBody;
-  for (let i = 0; i < boxes.length; i++) {
-    console.log(boxes[i].id);
-    const productBox = await ProductBox.findByPk(boxes[i].id);
-    if (!productBox) return setResponse(404, 'ProductBox not found.');
+  try {
+    const results = await moveProductBoxes(reqBody.boxes, reqUser);
+    return setResponse(200, 'ProductBoxes updated.', results);
+  } catch (error) {
+    if (error instanceof InventoryOperationError)
+      return setResponse(error.status, 'ProductBox movement failed.', null, error.userMessage);
+    throw error;
   }
-  for (let i = 0; i < boxes.length; i++) {
-    const productBox = await ProductBox.findByPk(boxes[i].id);
-    const item = {
-      warehouseId: boxes[i].warehouseId,
-      previousWarehouseId: boxes[i].previousWarehouseId,
-    };
-    await productBox.update(item);
-    productBox.registerLog(reqBody.message, reqUser);
-  }
-  return setResponse(200, 'ProductBox updated.', boxes);
 };
 
 const columns = [{ label: 'CODIGO CAJAS', value: 'code' }];
@@ -91,6 +104,7 @@ const getAvailableReport = async reqQuery => {
   const productBoxes = await ProductBox.findAll({
     where: {
       stock: { [Op.gt]: 0 },
+      inventoryKind: 'PHYSICAL',
     },
     attributes: ['trackingCode', 'boxSize', 'stock', 'createdAt'],
     include: [
@@ -159,6 +173,7 @@ const getMovementReport = async reqQuery => {
     include: [
       {
         model: ProductBox,
+        where: { inventoryKind: 'PHYSICAL' },
         attributes: ['trackingCode', 'stock'],
         include: [
           {

--- a/api/inventory/productbox/productbox.validator.js
+++ b/api/inventory/productbox/productbox.validator.js
@@ -31,22 +31,16 @@ const Put = {
 
 const PutMove = {
   body: {
-    boxes: Joi.array().items(
-      Joi.object({
-        id: Joi.number()
-          .integer()
-          .min(1)
-          .required(),
-        warehouseId: Joi.number()
-          .integer()
-          .min(1)
-          .required(),
-        previousWarehouseId: Joi.number()
-          .integer()
-          .min(1)
-          .required(),
-      }),
-    ),
+    boxes: Joi.array()
+      .items(
+        Joi.object({
+          id: Joi.number().integer().min(1).required(),
+          warehouseId: Joi.number().integer().min(1).required(),
+          previousWarehouseId: Joi.number().integer().min(1),
+        }),
+      )
+      .min(1)
+      .required(),
   },
 };
 

--- a/api/inventory/reconciliation/inventoryReconciliation.model.js
+++ b/api/inventory/reconciliation/inventoryReconciliation.model.js
@@ -1,0 +1,44 @@
+const { Model } = require('sequelize');
+
+module.exports = (sequelize, DataTypes) => {
+  class InventoryReconciliation extends Model {
+    static associate(models) {
+      InventoryReconciliation.belongsTo(models.Product);
+      InventoryReconciliation.belongsTo(models.Warehouse);
+      InventoryReconciliation.belongsTo(models.Warehouse, {
+        as: 'adjustmentWarehouse',
+        foreignKey: 'adjustmentWarehouseId',
+      });
+      InventoryReconciliation.belongsTo(models.Supply);
+      InventoryReconciliation.belongsTo(models.User, {
+        as: 'creator',
+        foreignKey: 'createdBy',
+      });
+      InventoryReconciliation.belongsTo(models.User, {
+        as: 'confirmer',
+        foreignKey: 'confirmedBy',
+      });
+      InventoryReconciliation.hasMany(models.InventoryMovement, {
+        foreignKey: 'reconciliationId',
+      });
+    }
+  }
+
+  InventoryReconciliation.init(
+    {
+      productId: { type: DataTypes.INTEGER, allowNull: false },
+      warehouseId: DataTypes.INTEGER,
+      adjustmentWarehouseId: DataTypes.INTEGER,
+      systemStock: { type: DataTypes.INTEGER, allowNull: false },
+      countedStock: { type: DataTypes.INTEGER, allowNull: false },
+      delta: { type: DataTypes.INTEGER, allowNull: false },
+      status: { type: DataTypes.STRING, allowNull: false, defaultValue: 'COMPLETED' },
+      supplyId: DataTypes.INTEGER,
+      createdBy: { type: DataTypes.INTEGER, allowNull: false },
+      confirmedBy: DataTypes.INTEGER,
+    },
+    { sequelize, modelName: 'inventoryReconciliation' },
+  );
+
+  return InventoryReconciliation;
+};

--- a/api/inventory/reconciliation/reconciliation.controller.js
+++ b/api/inventory/reconciliation/reconciliation.controller.js
@@ -1,0 +1,18 @@
+const Service = require('./reconciliation.service');
+const preview = async (req, res) => {
+  const response = await Service.preview(req.query);
+  return res.status(response.status).send(response);
+};
+const confirm = async (req, res) => {
+  const response = await Service.confirm(req.body, req.user);
+  return res.status(response.status).send(response);
+};
+const list = async (req, res) => {
+  const response = await Service.list(req.query);
+  return res.status(response.status).send(response);
+};
+const read = async (req, res) => {
+  const response = await Service.read(req.params);
+  return res.status(response.status).send(response);
+};
+module.exports = { preview, confirm, list, read };

--- a/api/inventory/reconciliation/reconciliation.router.js
+++ b/api/inventory/reconciliation/reconciliation.router.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const { celebrate } = require('celebrate');
+const { isAble } = require('@/middleware/authorization');
+const Controller = require('./reconciliation.controller');
+const Validator = require('./reconciliation.validator');
+
+const router = express.Router();
+router.get('/preview', isAble('reconcile', 'inventory'), celebrate(Validator.Preview), Controller.preview);
+router.post('/', isAble('reconcile', 'inventory'), celebrate(Validator.Confirm), Controller.confirm);
+router.get('/:id', isAble('read', 'inventory'), celebrate(Validator.Read), Controller.read);
+router.get('/', isAble('read', 'inventory'), celebrate(Validator.List), Controller.list);
+module.exports = router;

--- a/api/inventory/reconciliation/reconciliation.service.js
+++ b/api/inventory/reconciliation/reconciliation.service.js
@@ -1,0 +1,351 @@
+const { Op } = require('sequelize');
+const {
+  InventoryMovement,
+  InventoryReconciliation,
+  Product,
+  ProductBox,
+  SuppliedProduct,
+  Supply,
+  SupplyLog,
+  Warehouse,
+} = require('@dbModels');
+const { sequelize } = require('@root/startup/db');
+const {
+  setResponse,
+  supplyStatus,
+  warehouseTypes,
+} = require('@/utils');
+
+const activeWarehouseTypes = [warehouseTypes.WAREHOUSE, warehouseTypes.STORE];
+
+const loadSnapshot = async (productId, options = {}) => {
+  const boxes = await ProductBox.findAll({
+    where: { productId, stock: { [Op.gt]: 0 } },
+    include: [
+      {
+        model: Warehouse,
+        attributes: ['id', 'name', 'type'],
+        required: true,
+      },
+    ],
+    order: [['createdAt', 'ASC'], ['id', 'ASC']],
+    transaction: options.transaction,
+    lock: options.lock,
+  });
+  const activeBoxes = boxes.filter(box => activeWarehouseTypes.includes(box.warehouse.type));
+  return {
+    systemStock: activeBoxes.reduce((sum, box) => sum + box.stock, 0),
+    totalStock: boxes.reduce((sum, box) => sum + box.stock, 0),
+    boxes,
+    activeBoxes,
+  };
+};
+
+const serializeSource = box => ({
+  productBoxId: box.id,
+  trackingCode: box.trackingCode,
+  inventoryKind: box.inventoryKind,
+  lifecycleStatus: box.lifecycleStatus,
+  stock: box.stock,
+  warehouseId: box.warehouseId,
+  warehouseName: box.warehouse.name,
+  warehouseType: box.warehouse.type,
+  originProductBoxId: box.originProductBoxId,
+});
+
+const preview = async reqQuery => {
+  const product = await Product.findByPk(reqQuery.productId);
+  if (!product) return setResponse(404, 'Product not found.', null, 'Producto no encontrado.');
+
+  const warehouse = await Warehouse.findByPk(reqQuery.warehouseId);
+  if (!warehouse || warehouse.type !== warehouseTypes.STORE)
+    return setResponse(400, 'Invalid store.', null, 'Debe seleccionar una tienda válida.');
+
+  const snapshot = await loadSnapshot(product.id);
+  const countedStock = Number(reqQuery.countedStock);
+  const delta = countedStock - snapshot.systemStock;
+
+  return setResponse(200, 'Inventory reconciliation preview.', {
+    product,
+    warehouse,
+    totalStock: snapshot.totalStock,
+    systemStock: snapshot.systemStock,
+    countedStock,
+    delta,
+    sources: delta < 0 ? snapshot.activeBoxes.map(serializeSource) : [],
+  });
+};
+
+const getAdjustmentWarehouse = async transaction => {
+  let warehouse = await Warehouse.findOne({
+    where: { type: warehouseTypes.ADJUSTMENT },
+    transaction,
+    lock: transaction.LOCK.UPDATE,
+  });
+  if (!warehouse) {
+    warehouse = await Warehouse.create(
+      { name: 'Ajuste Inventario', address: '-', type: warehouseTypes.ADJUSTMENT },
+      { transaction },
+    );
+  }
+  return warehouse;
+};
+
+const createIncrease = async ({ product, warehouse, delta, reconciliation, user }, transaction) => {
+  const supply = await Supply.create(
+    {
+      providerId: product.providerId,
+      warehouseId: warehouse.id,
+      code: `AJUSTE-${reconciliation.id}`,
+      observations: 'Ajuste Inventario',
+      status: supplyStatus.ATTENDED,
+      attentionDate: new Date(),
+      type: 'INVENTORY_ADJUSTMENT',
+    },
+    { transaction },
+  );
+  const suppliedProduct = await SuppliedProduct.create(
+    {
+      quantity: 1,
+      initQuantity: 1,
+      suppliedQuantity: 1,
+      maxIndexSupplied: 1,
+      boxSize: delta,
+      initBoxSize: delta,
+      status: supplyStatus.ATTENDED,
+      supplyId: supply.id,
+      productId: product.id,
+    },
+    { transaction },
+  );
+  const lot = await ProductBox.create(
+    {
+      trackingCode: null,
+      boxSize: delta,
+      stock: delta,
+      isAvailable: true,
+      inventoryKind: 'EXPLODED',
+      lifecycleStatus: 'ACTIVE',
+      originProductBoxId: null,
+      explodedAt: new Date(),
+      explodedBy: user.id,
+      sourceType: 'RECONCILIATION',
+      productId: product.id,
+      warehouseId: warehouse.id,
+      supplyId: supply.id,
+      suppliedProductId: suppliedProduct.id,
+    },
+    { transaction },
+  );
+  await reconciliation.update({ supplyId: supply.id }, { transaction });
+  await InventoryMovement.create(
+    {
+      type: 'RECONCILIATION_IN',
+      quantity: delta,
+      productId: product.id,
+      targetProductBoxId: lot.id,
+      toWarehouseId: warehouse.id,
+      targetStockBefore: 0,
+      targetStockAfter: delta,
+      userId: user.id,
+      supplyId: supply.id,
+      reconciliationId: reconciliation.id,
+      description: 'Aumento por Ajuste Inventario',
+    },
+    { transaction },
+  );
+  if (SupplyLog)
+    await SupplyLog.create(
+      {
+        log: 'Abastecimiento creado por reconciliación',
+        action: 'INVENTORY_ADJUSTMENT',
+        detail: `+${delta} unidades`,
+        userId: user.id,
+        supplyId: supply.id,
+      },
+      { transaction },
+    );
+  return { supply, lot };
+};
+
+const createDecrease = async (
+  { product, sources, expectedQuantity, reconciliation, user },
+  transaction,
+) => {
+  if (!sources || !sources.length)
+    throw new Error('Debe seleccionar las fuentes del ajuste.');
+  const uniqueIds = new Set(sources.map(source => source.productBoxId));
+  if (uniqueIds.size !== sources.length)
+    throw new Error('No puede seleccionar una fuente más de una vez.');
+  const selectedTotal = sources.reduce((sum, source) => sum + source.quantity, 0);
+  if (selectedTotal !== expectedQuantity)
+    throw new Error('Las cantidades seleccionadas deben coincidir exactamente con el faltante.');
+
+  const boxes = await ProductBox.findAll({
+    where: { id: [...uniqueIds], productId: product.id },
+    include: [{ model: Warehouse, required: true }],
+    transaction,
+    lock: transaction.LOCK.UPDATE,
+  });
+  if (boxes.length !== uniqueIds.size) throw new Error('Una de las fuentes ya no existe.');
+
+  const adjustmentWarehouse = await getAdjustmentWarehouse(transaction);
+  await reconciliation.update(
+    { adjustmentWarehouseId: adjustmentWarehouse.id },
+    { transaction },
+  );
+  const adjustmentLot = await ProductBox.create(
+    {
+      trackingCode: null,
+      boxSize: expectedQuantity,
+      stock: expectedQuantity,
+      isAvailable: false,
+      inventoryKind: 'EXPLODED',
+      lifecycleStatus: 'ACTIVE',
+      explodedAt: new Date(),
+      explodedBy: user.id,
+      sourceType: 'RECONCILIATION_ADJUSTMENT',
+      productId: product.id,
+      warehouseId: adjustmentWarehouse.id,
+    },
+    { transaction },
+  );
+
+  let targetBefore = 0;
+  for (const selected of sources) {
+    const source = boxes.find(box => box.id === selected.productBoxId);
+    if (!source || !activeWarehouseTypes.includes(source.warehouse.type))
+      throw new Error('Una fuente seleccionada no pertenece al inventario activo.');
+    if (source.inventoryKind === 'PHYSICAL' && source.lifecycleStatus !== 'ACTIVE')
+      throw new Error('Una caja seleccionada ya fue explotada.');
+    if (selected.quantity <= 0 || selected.quantity > source.stock)
+      throw new Error('Una cantidad seleccionada excede el stock disponible.');
+
+    const sourceBefore = source.stock;
+    const sourceAfter = sourceBefore - selected.quantity;
+    await source.update(
+      { stock: sourceAfter, isAvailable: sourceAfter > 0 },
+      { transaction },
+    );
+    await source.registerLog(
+      `Ajuste Inventario: ${selected.quantity} unidades no disponibles`,
+      user,
+      { transaction },
+    );
+    await InventoryMovement.create(
+      {
+        type: 'RECONCILIATION_TO_ADJUSTMENT',
+        quantity: selected.quantity,
+        productId: product.id,
+        sourceProductBoxId: source.id,
+        targetProductBoxId: adjustmentLot.id,
+        fromWarehouseId: source.warehouseId,
+        toWarehouseId: adjustmentWarehouse.id,
+        sourceStockBefore: sourceBefore,
+        sourceStockAfter: sourceAfter,
+        targetStockBefore: targetBefore,
+        targetStockAfter: targetBefore + selected.quantity,
+        userId: user.id,
+        reconciliationId: reconciliation.id,
+        description: 'Stock reclasificado como no disponible',
+      },
+      { transaction },
+    );
+    targetBefore += selected.quantity;
+  }
+  return { adjustmentWarehouse, adjustmentLot };
+};
+
+const confirm = async (reqBody, reqUser) => {
+  const transaction = await sequelize.transaction();
+  try {
+    const product = await Product.findByPk(reqBody.productId, {
+      transaction,
+      lock: transaction.LOCK.UPDATE,
+    });
+    if (!product) throw new Error('Producto no encontrado.');
+    const warehouse = await Warehouse.findByPk(reqBody.warehouseId, {
+      transaction,
+      lock: transaction.LOCK.SHARE,
+    });
+    if (!warehouse || warehouse.type !== warehouseTypes.STORE)
+      throw new Error('Debe seleccionar una tienda válida.');
+
+    const snapshot = await loadSnapshot(product.id, {
+      transaction,
+      lock: transaction.LOCK.UPDATE,
+    });
+    if (snapshot.systemStock !== reqBody.systemStock)
+      throw new Error('El inventario cambió desde la vista previa. Vuelva a calcular el ajuste.');
+
+    const delta = reqBody.countedStock - snapshot.systemStock;
+    const reconciliation = await InventoryReconciliation.create(
+      {
+        productId: product.id,
+        warehouseId: warehouse.id,
+        systemStock: snapshot.systemStock,
+        countedStock: reqBody.countedStock,
+        delta,
+        status: 'COMPLETED',
+        createdBy: reqUser.id,
+        confirmedBy: reqUser.id,
+      },
+      { transaction },
+    );
+
+    let operation = null;
+    if (delta > 0)
+      operation = await createIncrease(
+        { product, warehouse, delta, reconciliation, user: reqUser },
+        transaction,
+      );
+    if (delta < 0)
+      operation = await createDecrease(
+        {
+          product,
+          sources: reqBody.sources,
+          expectedQuantity: Math.abs(delta),
+          reconciliation,
+          user: reqUser,
+        },
+        transaction,
+      );
+
+    await Product.updateStock(product.id, { transaction });
+    await transaction.commit();
+    return setResponse(201, 'Inventory reconciled.', { reconciliation, operation });
+  } catch (error) {
+    await transaction.rollback();
+    return setResponse(400, 'Inventory reconciliation failed.', null, error.message);
+  }
+};
+
+const list = async reqQuery => {
+  const reconciliations = await InventoryReconciliation.findAll({
+    where: reqQuery,
+    include: [
+      Product,
+      Warehouse,
+      { model: Warehouse, as: 'adjustmentWarehouse' },
+      InventoryMovement,
+    ],
+    order: [['createdAt', 'DESC']],
+  });
+  return setResponse(200, 'Inventory reconciliations found.', reconciliations);
+};
+
+const read = async reqParams => {
+  const reconciliation = await InventoryReconciliation.findByPk(reqParams.id, {
+    include: [
+      Product,
+      Warehouse,
+      { model: Warehouse, as: 'adjustmentWarehouse' },
+      InventoryMovement,
+    ],
+  });
+  if (!reconciliation)
+    return setResponse(404, 'Inventory reconciliation not found.', null, 'Reconciliación no encontrada.');
+  return setResponse(200, 'Inventory reconciliation found.', reconciliation);
+};
+
+module.exports = { confirm, list, preview, read };

--- a/api/inventory/reconciliation/reconciliation.validator.js
+++ b/api/inventory/reconciliation/reconciliation.validator.js
@@ -1,0 +1,28 @@
+const { Joi } = require('celebrate');
+module.exports = {
+  Preview: {
+    query: {
+      productId: Joi.number().integer().min(1).required(),
+      warehouseId: Joi.number().integer().min(1).required(),
+      countedStock: Joi.number().integer().min(0).required(),
+    },
+  },
+  Confirm: {
+    body: {
+      productId: Joi.number().integer().min(1).required(),
+      warehouseId: Joi.number().integer().min(1).required(),
+      countedStock: Joi.number().integer().min(0).required(),
+      systemStock: Joi.number().integer().min(0).required(),
+      sources: Joi.array()
+        .items(
+          Joi.object({
+            productBoxId: Joi.number().integer().min(1).required(),
+            quantity: Joi.number().integer().min(1).required(),
+          }),
+        )
+        .default([]),
+    },
+  },
+  List: { query: { productId: Joi.number().integer().min(1) } },
+  Read: { params: { id: Joi.number().integer().min(1).required() } },
+};

--- a/api/inventory/supply/supply.model.js
+++ b/api/inventory/supply/supply.model.js
@@ -10,6 +10,8 @@ module.exports = (sequelize, DataTypes) => {
     static associate(models) {
       Supply.hasMany(models.SuppliedProduct);
       Supply.hasMany(models.ProductBox);
+      Supply.hasMany(models.InventoryMovement);
+      Supply.hasMany(models.InventoryReconciliation);
 
       Supply.belongsTo(models.Warehouse);
       Supply.belongsTo(models.Provider);
@@ -33,6 +35,10 @@ module.exports = (sequelize, DataTypes) => {
       },
       observations: {
         type: DataTypes.TEXT,
+      },
+      type: {
+        type: DataTypes.STRING,
+        defaultValue: 'NORMAL',
       },
       status: {
         type: DataTypes.ENUM(statuses),

--- a/api/inventory/supply/supply.service/updateAttendSuppliedProduct.js
+++ b/api/inventory/supply/supply.service/updateAttendSuppliedProduct.js
@@ -1,14 +1,23 @@
 /* eslint-disable import/no-dynamic-require */
 const winston = require('winston');
-const { Supply, SuppliedProduct, ProductBox, Product } = require('@dbModels');
+const {
+  InventoryMovement,
+  Supply,
+  SuppliedProduct,
+  ProductBox,
+  Product,
+  Warehouse,
+} = require('@dbModels');
 
 const { sequelize } = require(`@root/startup/db`);
 
 const {
   supplyStatus: status,
   PRODUCTBOX_UPDATES,
+  warehouseTypes,
 } = require('../../../utils/constants');
 const { setResponse } = require('../../../utils');
+const { moveLockedProductBox } = require('../../inventoryTransaction.service');
 
 const validateAttendSuppliedProduct = async (reqBody, reqParams) => {
   const suppliedProduct = await SuppliedProduct.findByPk(
@@ -83,15 +92,54 @@ const updateAttendSuppliedProduct = async (reqBody, reqParams, reqUser) => {
     );
     await suppliedProduct.save({ transaction: t });
 
-    await Product.updateStock(suppliedProduct.productId, { transaction: t });
-
-    await t.commit();
     await ProductBox.bulkRegisterLog(
       PRODUCTBOX_UPDATES.CREATION.value,
       reqUser,
       newProductBoxes,
+      { transaction: t },
     );
-    return setResponse(200, 'Supplied Product attended.', newProductBoxes);
+
+    await InventoryMovement.bulkCreate(
+      newProductBoxes.map(productBox => ({
+        type: 'SUPPLY',
+        quantity: productBox.stock,
+        productId: productBox.productId,
+        targetProductBoxId: productBox.id,
+        toWarehouseId: productBox.warehouseId,
+        targetStockBefore: 0,
+        targetStockAfter: productBox.stock,
+        userId: reqUser.id,
+        supplyId: productBox.supplyId,
+        description: 'Ingreso por abastecimiento',
+      })),
+      { transaction: t },
+    );
+
+    const supplyWarehouse = await Warehouse.findByPk(
+      suppliedProduct.supply.warehouseId,
+      { transaction: t },
+    );
+    let attendedProductBoxes = newProductBoxes;
+    if (supplyWarehouse.type === warehouseTypes.STORE) {
+      const explosionResults = [];
+      for (const productBox of newProductBoxes)
+        explosionResults.push(
+          await moveLockedProductBox(
+            { productBoxId: productBox.id, warehouseId: supplyWarehouse.id },
+            reqUser,
+            t,
+          ),
+        );
+      attendedProductBoxes = explosionResults.map(result => {
+        result.productBox.setDataValue('explodedLot', result.explodedLot);
+        return result.productBox;
+      });
+    }
+
+    await Product.updateStock(suppliedProduct.productId, { transaction: t });
+
+    await t.commit();
+    return setResponse(200, 'Supplied Product attended.', attendedProductBoxes);
   } catch (error) {
     winston.error(error);
     // If the execution reaches this line, an error was thrown.

--- a/api/inventory/unitInventory.utils.js
+++ b/api/inventory/unitInventory.utils.js
@@ -1,0 +1,15 @@
+const buildUnitBarcode = productId => `2${String(productId).padStart(15, '0')}`;
+
+const allocateStock = (lots, quantity) => {
+  let remaining = quantity;
+  const allocations = [];
+  for (const lot of lots) {
+    if (remaining <= 0) break;
+    const allocated = Math.min(lot.stock, remaining);
+    if (allocated > 0) allocations.push({ lot, quantity: allocated });
+    remaining -= allocated;
+  }
+  return { allocations, remaining };
+};
+
+module.exports = { allocateStock, buildUnitBarcode };

--- a/api/inventory/unitTicketPrint/unitTicketPrint.controller.js
+++ b/api/inventory/unitTicketPrint/unitTicketPrint.controller.js
@@ -1,0 +1,14 @@
+const Service = require('./unitTicketPrint.service');
+const create = async (req, res) => {
+  const response = await Service.create(req.body, req.user);
+  return res.status(response.status).send(response);
+};
+const read = async (req, res) => {
+  const response = await Service.read(req.params);
+  return res.status(response.status).send(response);
+};
+const list = async (req, res) => {
+  const response = await Service.list(req.query);
+  return res.status(response.status).send(response);
+};
+module.exports = { create, read, list };

--- a/api/inventory/unitTicketPrint/unitTicketPrint.model.js
+++ b/api/inventory/unitTicketPrint/unitTicketPrint.model.js
@@ -1,0 +1,30 @@
+const { Model } = require('sequelize');
+
+module.exports = (sequelize, DataTypes) => {
+  class UnitTicketPrint extends Model {
+    static associate(models) {
+      UnitTicketPrint.belongsTo(models.Product);
+      UnitTicketPrint.belongsTo(models.ProductBox);
+      UnitTicketPrint.belongsTo(models.Warehouse);
+      UnitTicketPrint.belongsTo(models.User);
+      UnitTicketPrint.belongsTo(models.UnitTicketPrint, {
+        as: 'reprintOf',
+        foreignKey: 'reprintOfId',
+      });
+    }
+  }
+
+  UnitTicketPrint.init(
+    {
+      productId: { type: DataTypes.INTEGER, allowNull: false },
+      productBoxId: DataTypes.INTEGER,
+      warehouseId: DataTypes.INTEGER,
+      quantity: { type: DataTypes.INTEGER, allowNull: false },
+      reprintOfId: DataTypes.INTEGER,
+      userId: { type: DataTypes.INTEGER, allowNull: false },
+    },
+    { sequelize, modelName: 'unitTicketPrint' },
+  );
+
+  return UnitTicketPrint;
+};

--- a/api/inventory/unitTicketPrint/unitTicketPrint.router.js
+++ b/api/inventory/unitTicketPrint/unitTicketPrint.router.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const { celebrate } = require('celebrate');
+const { isAble } = require('@/middleware/authorization');
+const Controller = require('./unitTicketPrint.controller');
+const Validator = require('./unitTicketPrint.validator');
+
+const router = express.Router();
+router.post('/', isAble('print', 'inventory'), celebrate(Validator.Create), Controller.create);
+router.get('/:id', isAble('read', 'inventory'), celebrate(Validator.Read), Controller.read);
+router.get('/', isAble('read', 'inventory'), celebrate(Validator.List), Controller.list);
+module.exports = router;

--- a/api/inventory/unitTicketPrint/unitTicketPrint.service.js
+++ b/api/inventory/unitTicketPrint/unitTicketPrint.service.js
@@ -1,0 +1,71 @@
+const {
+  Product,
+  ProductBarcode,
+  ProductBox,
+  Provider,
+  UnitTicketPrint,
+  Warehouse,
+} = require('@dbModels');
+const { setResponse } = require('@/utils');
+const { ensureProductBarcode } = require('../productBarcode/productBarcode.service');
+
+const create = async (reqBody, reqUser) => {
+  const product = await Product.findByPk(reqBody.productId, { include: [Provider] });
+  if (!product) return setResponse(404, 'Product not found.', null, 'Producto no encontrado.');
+
+  let productBox = null;
+  if (reqBody.productBoxId) {
+    productBox = await ProductBox.findByPk(reqBody.productBoxId);
+    if (!productBox || productBox.productId !== product.id)
+      return setResponse(400, 'Invalid origin product box.', null, 'La caja origen no pertenece al producto.');
+  }
+
+  if (reqBody.warehouseId) {
+    const warehouse = await Warehouse.findByPk(reqBody.warehouseId);
+    if (!warehouse)
+      return setResponse(404, 'Warehouse not found.', null, 'Ubicación no encontrada.');
+  }
+
+  if (reqBody.reprintOfId) {
+    const original = await UnitTicketPrint.findByPk(reqBody.reprintOfId);
+    if (!original || original.productId !== product.id)
+      return setResponse(400, 'Invalid reprint reference.', null, 'La impresión original no es válida.');
+  }
+
+  const barcode = await ensureProductBarcode(product, { userId: reqUser.id });
+  const print = await UnitTicketPrint.create({
+    ...reqBody,
+    userId: reqUser.id,
+    warehouseId: reqBody.warehouseId || (productBox && productBox.warehouseId),
+  });
+  return setResponse(201, 'Unit ticket print created.', {
+    print,
+    product,
+    productBarcode: barcode,
+    originProductBox: productBox,
+  });
+};
+
+const read = async reqParams => {
+  const print = await UnitTicketPrint.findByPk(reqParams.id, {
+    include: [
+      { model: Product, include: [Provider, ProductBarcode] },
+      ProductBox,
+      Warehouse,
+    ],
+  });
+  if (!print)
+    return setResponse(404, 'Unit ticket print not found.', null, 'Impresión no encontrada.');
+  return setResponse(200, 'Unit ticket print found.', print);
+};
+
+const list = async reqQuery => {
+  const prints = await UnitTicketPrint.findAll({
+    where: reqQuery,
+    include: [Product, ProductBox, Warehouse],
+    order: [['createdAt', 'DESC']],
+  });
+  return setResponse(200, 'Unit ticket prints found.', prints);
+};
+
+module.exports = { create, read, list };

--- a/api/inventory/unitTicketPrint/unitTicketPrint.validator.js
+++ b/api/inventory/unitTicketPrint/unitTicketPrint.validator.js
@@ -1,0 +1,20 @@
+const { Joi } = require('celebrate');
+module.exports = {
+  Create: {
+    body: {
+      productId: Joi.number().integer().min(1).required(),
+      productBoxId: Joi.number().integer().min(1),
+      warehouseId: Joi.number().integer().min(1),
+      quantity: Joi.number().integer().min(1).max(10000).required(),
+      reprintOfId: Joi.number().integer().min(1),
+    },
+  },
+  Read: { params: { id: Joi.number().integer().min(1).required() } },
+  List: {
+    query: {
+      productId: Joi.number().integer().min(1),
+      productBoxId: Joi.number().integer().min(1),
+      warehouseId: Joi.number().integer().min(1),
+    },
+  },
+};

--- a/api/inventory/warehouse/warehouse.model.js
+++ b/api/inventory/warehouse/warehouse.model.js
@@ -10,6 +10,8 @@ module.exports = (sequelize, DataTypes) => {
 
       Warehouse.hasMany(models.Supply);
       Warehouse.hasMany(models.DispatchedProductBox);
+      Warehouse.hasMany(models.UnitTicketPrint);
+      Warehouse.hasMany(models.InventoryReconciliation);
     }
   }
   Warehouse.init(
@@ -24,7 +26,12 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false,
       },
       type: {
-        type: DataTypes.ENUM([types.WAREHOUSE, types.STORE, types.DAMAGED]),
+        type: DataTypes.ENUM([
+          types.WAREHOUSE,
+          types.STORE,
+          types.DAMAGED,
+          types.ADJUSTMENT,
+        ]),
         defaultValue: types.WAREHOUSE,
       },
     },

--- a/api/inventory/warehouse/warehouse.validator.js
+++ b/api/inventory/warehouse/warehouse.validator.js
@@ -4,7 +4,12 @@ const { warehouseTypes: types } = require('../../utils/constants');
 
 const List = {
   query: {
-    type: Joi.string().valid(types.WAREHOUSE, types.STORE, types.DAMAGED),
+    type: Joi.string().valid(
+      types.WAREHOUSE,
+      types.STORE,
+      types.DAMAGED,
+      types.ADJUSTMENT,
+    ),
   },
 };
 
@@ -26,6 +31,9 @@ const Post = {
       .max(255)
       .min(1)
       .required(),
+    type: Joi.string()
+      .valid(types.WAREHOUSE, types.STORE, types.DAMAGED, types.ADJUSTMENT)
+      .default(types.WAREHOUSE),
   },
 };
 module.exports = {

--- a/api/middleware/authorization/roles.js
+++ b/api/middleware/authorization/roles.js
@@ -1,7 +1,5 @@
 const { AbilityBuilder, Ability } = require('@casl/ability');
 
-const { ROLES } = require('@/utils');
-
 const roles = {
   superuser: (can, cannot) => {
     can('manage', 'all'); // read-write access to everything
@@ -20,6 +18,7 @@ const roles = {
     can('read', 'product');
     can('read', 'productBox');
     can('read', 'warehouse');
+    can('read', 'inventory');
 
     can('read', 'bank');
     can('manage', 'client');
@@ -41,6 +40,9 @@ const roles = {
     can('manage', 'product');
     can('manage', 'productBox');
     can('manage', 'warehouse');
+    can('read', 'inventory');
+    can('move', 'inventory');
+    can('print', 'inventory');
 
     can('manage', 'supply'); // ? Gestión y atención
     can('read', 'productBox');
@@ -64,6 +66,10 @@ const roles = {
     can('read', 'product');
     can('read', 'productBox');
     can('read', 'warehouse');
+    can('read', 'inventory');
+    can('move', 'inventory');
+    can('print', 'inventory');
+    can('reconcile', 'inventory');
 
     can('read', 'bank');
     can('manage', 'client');

--- a/api/sales/dispatch/dispatch.controller.js
+++ b/api/sales/dispatch/dispatch.controller.js
@@ -11,19 +11,10 @@ const getDispatch = async (req, res) => {
 };
 
 const postDispatchProductBox = async (req, res) => {
-  const validate = await Service.validatePostDispatchProductBox(
-    req.params,
-    req.body,
-  );
-
-  if (validate.status !== 200)
-    return res.status(validate.status).send(validate);
-
   const response = await Service.postDispatchProductBox(
     req.params,
     req.body,
     req.user,
-    validate.data,
   );
   return res.status(response.status).send(response);
 };

--- a/api/sales/dispatch/dispatch.model.js
+++ b/api/sales/dispatch/dispatch.model.js
@@ -15,6 +15,7 @@ module.exports = (sequelize, DataTypes) => {
       Dispatch.belongsTo(models.Proforma);
       Dispatch.belongsTo(models.Sale);
       Dispatch.belongsTo(models.DeliveryAgency);
+      Dispatch.hasMany(models.InventoryMovement);
     }
     // * INSTANCE METHODS
   }

--- a/api/sales/dispatch/dispatch.service/getDispatch.js
+++ b/api/sales/dispatch/dispatch.service/getDispatch.js
@@ -3,6 +3,7 @@ const {
   DispatchedProduct,
   DispatchedProductBox,
   Product,
+  ProductBarcode,
   Proforma,
   Client,
   User,
@@ -17,7 +18,16 @@ const getDispatch = async reqParams => {
         model: DispatchedProduct,
         include: [
           DispatchedProductBox,
-          Product,
+          {
+            model: Product,
+            include: [
+              {
+                model: ProductBarcode,
+                where: { type: 'UNIT_PRODUCT', isActive: true },
+                required: false,
+              },
+            ],
+          },
           { model: User, as: 'lastDispatcher' },
         ],
       },

--- a/api/sales/dispatch/dispatch.service/postDispatchProductBox.js
+++ b/api/sales/dispatch/dispatch.service/postDispatchProductBox.js
@@ -1,119 +1,147 @@
 const winston = require('winston');
-
+const { Op } = require('sequelize');
 const {
   Dispatch,
   DispatchedProduct,
-  DispatchedProductBox,
+  InventoryMovement,
+  ProductBarcode,
   ProductBox,
+  Warehouse,
 } = require('@dbModels');
-
-const { sequelize } = require(`@root/startup/db`);
+const { sequelize } = require('@root/startup/db');
+const { DISPATCH, warehouseTypes } = require('@/utils/constants');
 const { setResponse } = require('@/utils');
-const { DISPATCH } = require('@/utils/constants');
+const { allocateStock } = require('@/inventory/unitInventory.utils');
 
-// ? Se valida las componentes no transaccionales de la solicitud
-const validatePostDispatchProductBox = async (reqParams, reqBody) => {
-  const dispatchedProduct = await DispatchedProduct.findByPk(
-    reqParams.dispatchedProductId,
-    {
-      include: [
-        {
-          model: Dispatch,
-          where: { id: reqParams.id },
-        },
-      ],
-    },
-  );
-
-  if (!dispatchedProduct)
-    return setResponse(404, 'Dispatched product not found.');
-
-  if (dispatchedProduct.dispatch.status !== DISPATCH.STATUS.OPEN.value)
-    return setResponse(
-      400,
-      'Dispatch status is not open.',
-      null,
-      'El despacho esta bloqueado o ya ha sido completado.',
-    );
-
-  const productBox = await ProductBox.findByPk(reqBody.productBoxId);
-
-  if (!productBox) return setResponse(404, 'ProductBox not found.');
-
-  if (productBox.productId !== dispatchedProduct.productId)
-    return setResponse(
-      400,
-      'Product of product box different from dispatched product.',
-      null,
-      'La caja contiene productos distintos a los requeridos',
-    );
-
-  if (productBox.stock < reqBody.quantity)
-    return setResponse(
-      400,
-      'ProductBox stock is less than required.',
-      null,
-      'La caja no cuenta con productos suficientes.',
-    );
-  if (
-    dispatchedProduct.quantity - dispatchedProduct.dispatched <
-    reqBody.quantity
-  )
-    return setResponse(
-      400,
-      'DispatchedProduct remaining quantity is less than provided.',
-      null,
-      'La cantidad de unidades a despachar es mayor a la requerida.',
-    );
-
-  return setResponse(200, 'Ok.', { productBox });
+const fail = message => {
+  const error = new Error(message);
+  error.userMessage = message;
+  throw error;
 };
 
-const postDispatchProductBox = async (
-  reqParams,
-  reqBody,
-  reqUser,
-  validateData,
-) => {
-  const t = await sequelize.transaction();
+const allocateUnitLots = async ({ productId, warehouseId, quantity }, transaction) => {
+  const lots = await ProductBox.findAll({
+    where: {
+      productId,
+      warehouseId,
+      inventoryKind: 'EXPLODED',
+      lifecycleStatus: 'ACTIVE',
+      stock: { [Op.gt]: 0 },
+    },
+    order: [['createdAt', 'ASC'], ['id', 'ASC']],
+    transaction,
+    lock: transaction.LOCK.UPDATE,
+  });
+  const allocation = allocateStock(lots, quantity);
+  const allocations = allocation.allocations.map(item => ({
+    productBox: item.lot,
+    quantity: item.quantity,
+    stockBefore: item.lot.stock,
+  }));
+  const { remaining } = allocation;
+  if (remaining > 0) fail('La tienda no tiene stock unitario suficiente para este despacho.');
+  return allocations;
+};
 
+const postDispatchProductBox = async (reqParams, reqBody, reqUser) => {
+  const transaction = await sequelize.transaction();
   try {
     const dispatchedProduct = await DispatchedProduct.findByPk(
       reqParams.dispatchedProductId,
       {
-        where: { dispatchId: reqParams.id },
-        include: [Dispatch, DispatchedProductBox],
-
-        transaction: t,
+        include: [{ model: Dispatch, required: true }],
+        transaction,
+        lock: transaction.LOCK.UPDATE,
       },
     );
+    if (!dispatchedProduct || dispatchedProduct.dispatchId !== Number(reqParams.id))
+      fail('Producto de despacho no encontrado.');
+    if (dispatchedProduct.dispatch.status !== DISPATCH.STATUS.OPEN.value)
+      fail('El despacho está bloqueado o ya fue completado.');
+    if (reqBody.quantity <= 0)
+      fail('La cantidad debe ser mayor a cero.');
+    if (dispatchedProduct.quantity - dispatchedProduct.dispatched < reqBody.quantity)
+      fail('La cantidad es mayor a la pendiente de despacho.');
 
-    await dispatchedProduct.createDispatchedProductBox(
-      {
-        ...reqBody,
-        dispatcherId: reqUser.id,
-        warehouseId: validateData.productBox.warehouseId,
-      },
-      {
-        transaction: t,
-      },
-    );
+    let allocations;
+    if (reqBody.productBarcode) {
+      const [barcode, warehouse] = await Promise.all([
+        ProductBarcode.findOne({
+          where: { barcode: reqBody.productBarcode, type: 'UNIT_PRODUCT', isActive: true },
+          transaction,
+        }),
+        Warehouse.findByPk(reqBody.warehouseId, { transaction }),
+      ]);
+      if (!barcode) fail('El código de producto no fue encontrado.');
+      if (barcode.productId !== dispatchedProduct.productId)
+        fail('La etiqueta corresponde a un producto distinto al requerido.');
+      if (!warehouse || warehouse.type !== warehouseTypes.STORE)
+        fail('Debe seleccionar una tienda válida.');
+      allocations = await allocateUnitLots(
+        {
+          productId: dispatchedProduct.productId,
+          warehouseId: warehouse.id,
+          quantity: reqBody.quantity,
+        },
+        transaction,
+      );
+    } else {
+      const productBox = await ProductBox.findByPk(reqBody.productBoxId, {
+        include: [{ model: Warehouse, required: true }],
+        transaction,
+        lock: transaction.LOCK.UPDATE,
+      });
+      if (!productBox) fail('Caja no encontrada.');
+      if (productBox.inventoryKind !== 'PHYSICAL' || productBox.lifecycleStatus !== 'ACTIVE')
+        fail('La caja fue explotada y ya no puede despacharse como caja física.');
+      if ([warehouseTypes.DAMAGED, warehouseTypes.ADJUSTMENT].includes(productBox.warehouse.type))
+        fail('La caja pertenece a una ubicación no disponible.');
+      if (productBox.productId !== dispatchedProduct.productId)
+        fail('La caja contiene un producto distinto al requerido.');
+      if (productBox.stock < reqBody.quantity)
+        fail('La caja no cuenta con unidades suficientes.');
+      allocations = [
+        { productBox, quantity: reqBody.quantity, stockBefore: productBox.stock },
+      ];
+    }
 
-    await dispatchedProduct.setLastDispatcher(reqUser, { transaction: t });
-    await dispatchedProduct.dispatch.setDispatcher(reqUser, { transaction: t });
+    for (const allocation of allocations) {
+      await dispatchedProduct.createDispatchedProductBox(
+        {
+          productBoxId: allocation.productBox.id,
+          quantity: allocation.quantity,
+          dispatcherId: reqUser.id,
+          warehouseId: allocation.productBox.warehouseId,
+        },
+        { transaction },
+      );
+      await InventoryMovement.create(
+        {
+          type: 'DISPATCH',
+          quantity: allocation.quantity,
+          productId: dispatchedProduct.productId,
+          sourceProductBoxId: allocation.productBox.id,
+          fromWarehouseId: allocation.productBox.warehouseId,
+          sourceStockBefore: allocation.stockBefore,
+          sourceStockAfter: allocation.stockBefore - allocation.quantity,
+          userId: reqUser.id,
+          dispatchId: dispatchedProduct.dispatchId,
+          description: 'Despacho de producto',
+        },
+        { transaction },
+      );
+    }
 
-    await t.commit();
+    await dispatchedProduct.setLastDispatcher(reqUser, { transaction });
+    await dispatchedProduct.dispatch.setDispatcher(reqUser, { transaction });
+    await transaction.commit();
     await dispatchedProduct.reload();
-
     return setResponse(200, 'Product dispatched.', dispatchedProduct);
   } catch (error) {
     winston.error(error);
-    await t.rollback();
-    return setResponse(400, 'Dispatchment failed.');
+    await transaction.rollback();
+    return setResponse(400, 'Dispatchment failed.', null, error.userMessage || error.message);
   }
 };
 
-module.exports = {
-  validatePostDispatchProductBox,
-  postDispatchProductBox,
-};
+module.exports = { postDispatchProductBox };

--- a/api/sales/dispatch/dispatch.validator.js
+++ b/api/sales/dispatch/dispatch.validator.js
@@ -58,14 +58,15 @@ const PostDispatchProductBox = {
       .integer()
       .required(),
   },
-  body: {
-    productBoxId: Joi.number()
-      .integer()
-      .required(),
-    quantity: Joi.number()
-      .integer()
-      .required(),
-  },
+  body: Joi.object()
+    .keys({
+      productBoxId: Joi.number().integer().min(1),
+      productBarcode: Joi.string().pattern(/^2\d{15}$/),
+      warehouseId: Joi.number().integer().min(1),
+      quantity: Joi.number().integer().min(1).required(),
+    })
+    .xor('productBoxId', 'productBarcode')
+    .with('productBarcode', 'warehouseId'),
 };
 
 module.exports = {

--- a/api/sales/dispatch/dispatchedProductBox.model.js
+++ b/api/sales/dispatch/dispatchedProductBox.model.js
@@ -55,13 +55,16 @@ module.exports = (sequelize, DataTypes) => {
             transaction: t,
           });
 
-          productBox.registerLog(
+          if (productBox.stock <= 0)
+            await productBox.update({ isAvailable: false }, { transaction: t });
+
+          await productBox.registerLog(
             `Despachado ${dispatchedProductBox.quantity} unidades`,
             dispatchedProductBox.dispatcherId,
             { transaction: t },
           );
 
-          await Product.updateStock(dispatchedProductBox.productId, {
+          await Product.updateStock(productBox.productId, {
             transaction: t,
           });
         },

--- a/api/utils/constants/inventory.js
+++ b/api/utils/constants/inventory.js
@@ -11,6 +11,15 @@ module.exports = {
     WAREHOUSE: 'Almacén',
     STORE: 'Tienda',
     DAMAGED: 'Averiado',
+    ADJUSTMENT: 'AjusteInventario',
+  },
+  productBoxKinds: {
+    PHYSICAL: 'PHYSICAL',
+    EXPLODED: 'EXPLODED',
+  },
+  productBoxLifecycle: {
+    ACTIVE: 'ACTIVE',
+    DISCARDED: 'DISCARDED',
   },
   PRODUCTBOX_UPDATES: {
     MOVEMENT: { value: 'MOVEMENT', name: 'Movimiento de caja' },

--- a/migrations/20260710000000-unit-inventory-foundation.js
+++ b/migrations/20260710000000-unit-inventory-foundation.js
@@ -1,0 +1,400 @@
+'use strict';
+
+const addColumnIfMissing = async (queryInterface, table, column, definition) => {
+  const description = await queryInterface.describeTable(table);
+  if (!description[column]) await queryInterface.addColumn(table, column, definition);
+};
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.sequelize.query(`
+      ALTER TYPE "enum_warehouses_type"
+      ADD VALUE IF NOT EXISTS 'AjusteInventario';
+    `);
+
+    await addColumnIfMissing(queryInterface, 'supplies', 'type', {
+      type: Sequelize.STRING,
+      allowNull: false,
+      defaultValue: 'NORMAL',
+    });
+    await addColumnIfMissing(queryInterface, 'products', 'adjustmentStock', {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
+    });
+    await addColumnIfMissing(queryInterface, 'productBoxes', 'inventoryKind', {
+      type: Sequelize.STRING,
+      allowNull: false,
+      defaultValue: 'PHYSICAL',
+    });
+    await addColumnIfMissing(queryInterface, 'productBoxes', 'lifecycleStatus', {
+      type: Sequelize.STRING,
+      allowNull: false,
+      defaultValue: 'ACTIVE',
+    });
+    await addColumnIfMissing(queryInterface, 'productBoxes', 'originProductBoxId', {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+      references: { model: 'productBoxes', key: 'id' },
+      onUpdate: 'CASCADE',
+      onDelete: 'RESTRICT',
+    });
+    await addColumnIfMissing(queryInterface, 'productBoxes', 'explodedAt', {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
+    await addColumnIfMissing(queryInterface, 'productBoxes', 'explodedBy', {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+      references: { model: 'users', key: 'id' },
+      onUpdate: 'CASCADE',
+      onDelete: 'SET NULL',
+    });
+    await addColumnIfMissing(queryInterface, 'productBoxes', 'sourceType', {
+      type: Sequelize.STRING,
+      allowNull: false,
+      defaultValue: 'SUPPLY',
+    });
+
+    await queryInterface.sequelize.query(`
+      INSERT INTO "warehouses" ("name", "address", "type", "createdAt", "updatedAt")
+      SELECT 'Ajuste Inventario', '-', 'AjusteInventario', NOW(), NOW()
+      WHERE NOT EXISTS (
+        SELECT 1 FROM "warehouses" WHERE "type" = 'AjusteInventario'
+      );
+    `);
+
+    let tables = await queryInterface.showAllTables();
+    if (!tables.includes('productBarcodes')) {
+      await queryInterface.createTable('productBarcodes', {
+        id: { allowNull: false, autoIncrement: true, primaryKey: true, type: Sequelize.INTEGER },
+        barcode: { type: Sequelize.STRING, allowNull: false },
+        productId: {
+          type: Sequelize.INTEGER,
+          allowNull: false,
+          references: { model: 'products', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'CASCADE',
+        },
+        productCodeSnapshot: { type: Sequelize.STRING, allowNull: true },
+        type: { type: Sequelize.STRING, allowNull: false, defaultValue: 'UNIT_PRODUCT' },
+        isActive: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: true },
+        createdBy: {
+          type: Sequelize.INTEGER,
+          allowNull: true,
+          references: { model: 'users', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'SET NULL',
+        },
+        createdAt: { allowNull: false, type: Sequelize.DATE, defaultValue: Sequelize.fn('NOW') },
+        updatedAt: { allowNull: false, type: Sequelize.DATE, defaultValue: Sequelize.fn('NOW') },
+      });
+    }
+
+    if (!tables.includes('inventoryReconciliations')) {
+      await queryInterface.createTable('inventoryReconciliations', {
+        id: { allowNull: false, autoIncrement: true, primaryKey: true, type: Sequelize.INTEGER },
+        productId: {
+          type: Sequelize.INTEGER,
+          allowNull: false,
+          references: { model: 'products', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'RESTRICT',
+        },
+        warehouseId: {
+          type: Sequelize.INTEGER,
+          allowNull: true,
+          references: { model: 'warehouses', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'RESTRICT',
+        },
+        adjustmentWarehouseId: {
+          type: Sequelize.INTEGER,
+          allowNull: true,
+          references: { model: 'warehouses', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'RESTRICT',
+        },
+        systemStock: { type: Sequelize.INTEGER, allowNull: false },
+        countedStock: { type: Sequelize.INTEGER, allowNull: false },
+        delta: { type: Sequelize.INTEGER, allowNull: false },
+        status: { type: Sequelize.STRING, allowNull: false, defaultValue: 'COMPLETED' },
+        supplyId: {
+          type: Sequelize.INTEGER,
+          allowNull: true,
+          references: { model: 'supplies', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'SET NULL',
+        },
+        createdBy: {
+          type: Sequelize.INTEGER,
+          allowNull: false,
+          references: { model: 'users', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'RESTRICT',
+        },
+        confirmedBy: {
+          type: Sequelize.INTEGER,
+          allowNull: true,
+          references: { model: 'users', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'SET NULL',
+        },
+        createdAt: { allowNull: false, type: Sequelize.DATE, defaultValue: Sequelize.fn('NOW') },
+        updatedAt: { allowNull: false, type: Sequelize.DATE, defaultValue: Sequelize.fn('NOW') },
+      });
+    }
+
+    if (!tables.includes('inventoryMovements')) {
+      await queryInterface.createTable('inventoryMovements', {
+        id: { allowNull: false, autoIncrement: true, primaryKey: true, type: Sequelize.INTEGER },
+        type: { type: Sequelize.STRING, allowNull: false },
+        quantity: { type: Sequelize.INTEGER, allowNull: false },
+        productId: {
+          type: Sequelize.INTEGER,
+          allowNull: false,
+          references: { model: 'products', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'RESTRICT',
+        },
+        sourceProductBoxId: {
+          type: Sequelize.INTEGER,
+          allowNull: true,
+          references: { model: 'productBoxes', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'RESTRICT',
+        },
+        targetProductBoxId: {
+          type: Sequelize.INTEGER,
+          allowNull: true,
+          references: { model: 'productBoxes', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'RESTRICT',
+        },
+        fromWarehouseId: {
+          type: Sequelize.INTEGER,
+          allowNull: true,
+          references: { model: 'warehouses', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'RESTRICT',
+        },
+        toWarehouseId: {
+          type: Sequelize.INTEGER,
+          allowNull: true,
+          references: { model: 'warehouses', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'RESTRICT',
+        },
+        sourceStockBefore: { type: Sequelize.INTEGER, allowNull: true },
+        sourceStockAfter: { type: Sequelize.INTEGER, allowNull: true },
+        targetStockBefore: { type: Sequelize.INTEGER, allowNull: true },
+        targetStockAfter: { type: Sequelize.INTEGER, allowNull: true },
+        userId: {
+          type: Sequelize.INTEGER,
+          allowNull: true,
+          references: { model: 'users', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'SET NULL',
+        },
+        supplyId: {
+          type: Sequelize.INTEGER,
+          allowNull: true,
+          references: { model: 'supplies', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'SET NULL',
+        },
+        dispatchId: {
+          type: Sequelize.INTEGER,
+          allowNull: true,
+          references: { model: 'dispatches', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'SET NULL',
+        },
+        reconciliationId: {
+          type: Sequelize.INTEGER,
+          allowNull: true,
+          references: { model: 'inventoryReconciliations', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'SET NULL',
+        },
+        description: { type: Sequelize.TEXT, allowNull: true },
+        metadata: { type: Sequelize.JSONB, allowNull: true },
+        createdAt: { allowNull: false, type: Sequelize.DATE, defaultValue: Sequelize.fn('NOW') },
+        updatedAt: { allowNull: false, type: Sequelize.DATE, defaultValue: Sequelize.fn('NOW') },
+      });
+    }
+
+    if (!tables.includes('unitTicketPrints')) {
+      await queryInterface.createTable('unitTicketPrints', {
+        id: { allowNull: false, autoIncrement: true, primaryKey: true, type: Sequelize.INTEGER },
+        productId: {
+          type: Sequelize.INTEGER,
+          allowNull: false,
+          references: { model: 'products', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'RESTRICT',
+        },
+        productBoxId: {
+          type: Sequelize.INTEGER,
+          allowNull: true,
+          references: { model: 'productBoxes', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'SET NULL',
+        },
+        warehouseId: {
+          type: Sequelize.INTEGER,
+          allowNull: true,
+          references: { model: 'warehouses', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'SET NULL',
+        },
+        quantity: { type: Sequelize.INTEGER, allowNull: false },
+        reprintOfId: {
+          type: Sequelize.INTEGER,
+          allowNull: true,
+          references: { model: 'unitTicketPrints', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'SET NULL',
+        },
+        userId: {
+          type: Sequelize.INTEGER,
+          allowNull: false,
+          references: { model: 'users', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'RESTRICT',
+        },
+        createdAt: { allowNull: false, type: Sequelize.DATE, defaultValue: Sequelize.fn('NOW') },
+        updatedAt: { allowNull: false, type: Sequelize.DATE, defaultValue: Sequelize.fn('NOW') },
+      });
+    }
+
+    const addIndex = async (table, fields, name, options = {}) => {
+      const current = await queryInterface.showIndex(table);
+      if (!current.some(index => index.name === name))
+        await queryInterface.addIndex(table, fields, { name, ...options });
+    };
+    await addIndex('productBarcodes', ['barcode'], 'product_barcodes_barcode_unique', { unique: true });
+    await addIndex('productBarcodes', ['productId', 'type', 'isActive'], 'product_barcodes_product_active_idx');
+    await addIndex('productBoxes', ['originProductBoxId'], 'product_boxes_origin_idx');
+    await addIndex('productBoxes', ['productId', 'warehouseId', 'inventoryKind', 'stock'], 'product_boxes_unit_stock_idx');
+    await addIndex('inventoryMovements', ['productId', 'createdAt'], 'inventory_movements_product_date_idx');
+    await addIndex('inventoryMovements', ['reconciliationId'], 'inventory_movements_reconciliation_idx');
+    await addIndex('inventoryReconciliations', ['productId', 'createdAt'], 'inventory_reconciliations_product_date_idx');
+    await addIndex('unitTicketPrints', ['productId', 'createdAt'], 'unit_ticket_prints_product_date_idx');
+
+    await queryInterface.sequelize.query(`
+      INSERT INTO "productBarcodes"
+        ("barcode", "productId", "productCodeSnapshot", "type", "isActive", "createdAt", "updatedAt")
+      SELECT CONCAT('2', LPAD(CAST(p."id" AS TEXT), 15, '0')), p."id", p."code",
+             'UNIT_PRODUCT', TRUE, NOW(), NOW()
+      FROM "products" p
+      WHERE NOT EXISTS (
+        SELECT 1 FROM "productBarcodes" pb
+        WHERE pb."productId" = p."id" AND pb."type" = 'UNIT_PRODUCT' AND pb."isActive" = TRUE
+      );
+    `);
+
+    await queryInterface.sequelize.query(`
+      INSERT INTO "productBoxes"
+        ("trackingCode", "boxSize", "stock", "isAvailable", "inventoryKind",
+         "lifecycleStatus", "originProductBoxId", "explodedAt", "sourceType",
+         "productId", "warehouseId", "supplyId", "createdAt", "updatedAt")
+      SELECT NULL, pb."stock", pb."stock", TRUE, 'EXPLODED', 'ACTIVE', pb."id", NOW(),
+             'MIGRATION', pb."productId", pb."warehouseId", pb."supplyId", NOW(), NOW()
+      FROM "productBoxes" pb
+      JOIN "warehouses" w ON w."id" = pb."warehouseId"
+      WHERE w."type" = 'Tienda'
+        AND pb."stock" > 0
+        AND pb."inventoryKind" = 'PHYSICAL'
+        AND NOT EXISTS (
+          SELECT 1 FROM "productBoxes" child
+          WHERE child."originProductBoxId" = pb."id" AND child."sourceType" = 'MIGRATION'
+        );
+    `);
+
+    await queryInterface.sequelize.query(`
+      INSERT INTO "inventoryMovements"
+        ("type", "quantity", "productId", "sourceProductBoxId", "targetProductBoxId",
+         "fromWarehouseId", "toWarehouseId", "sourceStockBefore", "sourceStockAfter",
+         "targetStockBefore", "targetStockAfter", "description", "createdAt", "updatedAt")
+      SELECT 'INITIAL_STORE_MIGRATION', child."stock", parent."productId", parent."id", child."id",
+             parent."warehouseId", child."warehouseId", parent."stock", 0, 0, child."stock",
+             'Conversión inicial de inventario existente en tienda', NOW(), NOW()
+      FROM "productBoxes" child
+      JOIN "productBoxes" parent ON parent."id" = child."originProductBoxId"
+      WHERE child."sourceType" = 'MIGRATION'
+        AND NOT EXISTS (
+          SELECT 1 FROM "inventoryMovements" movement
+          WHERE movement."type" = 'INITIAL_STORE_MIGRATION'
+            AND movement."targetProductBoxId" = child."id"
+        );
+    `);
+
+    await queryInterface.sequelize.query(`
+      UPDATE "productBoxes" parent
+      SET "stock" = 0, "isAvailable" = FALSE, "lifecycleStatus" = 'DISCARDED',
+          "explodedAt" = COALESCE(parent."explodedAt", NOW()), "updatedAt" = NOW()
+      WHERE EXISTS (
+        SELECT 1 FROM "productBoxes" child
+        WHERE child."originProductBoxId" = parent."id" AND child."sourceType" = 'MIGRATION'
+      ) AND parent."stock" > 0;
+    `);
+  },
+
+  down: async queryInterface => {
+    const tables = await queryInterface.showAllTables();
+    if (tables.includes('productBoxes')) {
+      const description = await queryInterface.describeTable('productBoxes');
+      if (description.originProductBoxId) {
+        await queryInterface.sequelize.query(`
+          UPDATE "productBoxes" source
+          SET "stock" = source."stock" + restored."quantity",
+              "isAvailable" = TRUE,
+              "updatedAt" = NOW()
+          FROM (
+            SELECT "sourceProductBoxId", SUM("quantity") AS "quantity"
+            FROM "inventoryMovements"
+            WHERE "type" = 'RECONCILIATION_TO_ADJUSTMENT'
+              AND "sourceProductBoxId" IS NOT NULL
+            GROUP BY "sourceProductBoxId"
+          ) restored
+          WHERE source."id" = restored."sourceProductBoxId";
+        `);
+        await queryInterface.sequelize.query(`
+          UPDATE "productBoxes" parent
+          SET "stock" = parent."stock" + restored."stock",
+              "isAvailable" = (parent."stock" + restored."stock") > 0,
+              "lifecycleStatus" = 'ACTIVE', "explodedAt" = NULL, "updatedAt" = NOW()
+          FROM (
+            SELECT "originProductBoxId", SUM("stock") AS "stock"
+            FROM "productBoxes"
+            WHERE "inventoryKind" = 'EXPLODED' AND "originProductBoxId" IS NOT NULL
+            GROUP BY "originProductBoxId"
+          ) restored
+          WHERE parent."id" = restored."originProductBoxId";
+        `);
+      }
+    }
+
+    // Drop the audit tables before deleting logical lots because their foreign keys
+    // intentionally protect referenced inventory rows while the feature is active.
+    for (const table of ['unitTicketPrints', 'inventoryMovements', 'inventoryReconciliations', 'productBarcodes'])
+      if (tables.includes(table)) await queryInterface.dropTable(table);
+
+    if (tables.includes('productBoxes')) {
+      const description = await queryInterface.describeTable('productBoxes');
+      if (description.inventoryKind)
+        await queryInterface.sequelize.query(`DELETE FROM "productBoxes" WHERE "inventoryKind" = 'EXPLODED';`);
+    }
+
+    const removeColumnIfPresent = async (table, column) => {
+      const description = await queryInterface.describeTable(table);
+      if (description[column]) await queryInterface.removeColumn(table, column);
+    };
+    for (const column of ['originProductBoxId', 'explodedBy', 'explodedAt', 'sourceType', 'lifecycleStatus', 'inventoryKind'])
+      await removeColumnIfPresent('productBoxes', column);
+    await removeColumnIfPresent('products', 'adjustmentStock');
+    await removeColumnIfPresent('supplies', 'type');
+    // PostgreSQL enum values are intentionally not removed in down migrations.
+  },
+};

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "node": "22.x"
   },
   "scripts": {
+    "test": "node --test test/*.test.js",
     "start": "node  ./bin/www && npx sequelize-cli db:migrate",
     "startN": "set DEBUG=http & nodemon -e yml,js ./bin/www --trace-warnings",
     "prod": "NODE_ENV=production node ./bin/www",

--- a/test/inventoryPermissions.test.js
+++ b/test/inventoryPermissions.test.js
@@ -1,0 +1,20 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  defineAbilityFor,
+} = require('../api/middleware/authorization/roles');
+
+test('manager can reconcile and logistics can only read inventory history', () => {
+  const manager = defineAbilityFor('manager');
+  const logistic = defineAbilityFor('logistic');
+  assert.equal(manager.can('reconcile', 'inventory'), true);
+  assert.equal(logistic.can('read', 'inventory'), true);
+  assert.equal(logistic.can('reconcile', 'inventory'), false);
+});
+
+test('seller can resolve inventory codes but cannot print or reconcile', () => {
+  const seller = defineAbilityFor('seller');
+  assert.equal(seller.can('read', 'inventory'), true);
+  assert.equal(seller.can('print', 'inventory'), false);
+  assert.equal(seller.can('reconcile', 'inventory'), false);
+});

--- a/test/unitInventory.test.js
+++ b/test/unitInventory.test.js
@@ -1,0 +1,36 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  allocateStock,
+  buildUnitBarcode,
+} = require('../api/inventory/unitInventory.utils');
+
+test('unit barcode is stable, numeric, prefixed with 2 and 16 digits long', () => {
+  assert.equal(buildUnitBarcode(123), '2000000000000123');
+  assert.match(buildUnitBarcode(987654), /^2\d{15}$/);
+  assert.equal(buildUnitBarcode(123), buildUnitBarcode(123));
+  assert.notEqual(buildUnitBarcode(123), buildUnitBarcode(124));
+});
+
+test('FIFO allocation spans lots without exceeding requested quantity', () => {
+  const lots = [
+    { id: 1, stock: 5 },
+    { id: 2, stock: 4 },
+    { id: 3, stock: 8 },
+  ];
+  const result = allocateStock(lots, 7);
+  assert.equal(result.remaining, 0);
+  assert.deepEqual(
+    result.allocations.map(item => ({ id: item.lot.id, quantity: item.quantity })),
+    [
+      { id: 1, quantity: 5 },
+      { id: 2, quantity: 2 },
+    ],
+  );
+});
+
+test('allocation reports an unmet remainder when stock is insufficient', () => {
+  const result = allocateStock([{ id: 1, stock: 2 }], 5);
+  assert.equal(result.remaining, 3);
+  assert.equal(result.allocations[0].quantity, 2);
+});


### PR DESCRIPTION
- Created model for UnitTicketPrint with associations to Product, ProductBox, Warehouse, User, and reprint references.
- Implemented router for unit ticket print with create, read, and list endpoints.
- Developed service methods for creating, reading, and listing unit ticket prints, including validation for product and warehouse existence.
- Added validation for unit ticket print creation and retrieval.
- Updated Warehouse model to include associations with UnitTicketPrint and InventoryReconciliation.
- Enhanced authorization roles to include inventory-related permissions.
- Refactored dispatch service to support unit-level dispatching with barcode validation and stock allocation.
- Created migration for new inventory-related tables and columns, including unit ticket prints and inventory movements.
- Added tests for inventory permissions and unit inventory utilities.